### PR TITLE
Improve property test to reach interesting states

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,68 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.3",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,15 +36,6 @@ dependencies = [
  "object",
  "rustc-demangle",
  "windows-targets",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -137,82 +66,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
-name = "cc"
-version = "1.2.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
-dependencies = [
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
+name = "derivative"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "drift"
 version = "0.1.0"
 dependencies = [
- "loom",
- "madsim",
+ "derivative",
  "proptest",
  "proptest-derive",
  "thiserror",
@@ -237,27 +111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,63 +121,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-macro",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
-name = "generator"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows",
-]
 
 [[package]]
 name = "getrandom"
@@ -360,12 +156,6 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -412,77 +202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "madsim"
-version = "0.2.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c97f34bb19cf6a435a4da2187e90acc6bc59faa730e493b28b6d33e1bb9ccb"
-dependencies = [
- "ahash",
- "async-channel",
- "async-stream",
- "async-task",
- "bincode",
- "bytes",
- "downcast-rs",
- "futures-util",
- "lazy_static",
- "libc",
- "madsim-macros",
- "naive-timer",
- "panic-message",
- "rand 0.8.5",
- "rand_xoshiro",
- "rustversion",
- "serde",
- "spin",
- "tokio",
- "tokio-util",
- "toml",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "madsim-macros"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d248e97b1a48826a12c3828d921e8548e714394bf17274dd0a93910dc946e1"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,22 +228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "naive-timer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034a0ad7deebf0c2abcf2435950a6666c3c15ea9d8fad0c0f48efa8a7f843fed"
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,24 +251,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "panic-message"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e52fd8fbd4cbe3c317e8216260c21a0f9134de108cea8a4dd4e7e152c472d"
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -595,12 +280,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -634,7 +313,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -751,15 +430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,48 +439,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "c3160422bbd54dd5ecfdca71e5fd59b7b8fe2b1697ab2baf64f6d05dcc66d298"
 
 [[package]]
 name = "rustc-demangle"
@@ -830,12 +462,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-fork"
@@ -862,65 +488,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -938,21 +511,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1010,16 +568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
-
-[[package]]
 name = "tokio"
 version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,60 +595,6 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1131,36 +625,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -1191,18 +655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,130 +676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-link",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core",
- "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -1382,15 +710,6 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -1440,15 +759,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-loom = "0.7.2"
-madsim = "0.2.31"
+derivative = "2.2.0"
 proptest = "1.5"
 proptest-derive = "0.6.0"
 thiserror = "2.0.12"

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,3 @@
-use proptest::prelude::{Arbitrary, BoxedStrategy, Just, Strategy, any, prop, prop_oneof};
-use proptest_derive::Arbitrary;
-
 use crate::state::{Command, Index, LogEntry, NodeId, NonZeroIndex, Term};
 
 #[cfg(test)]
@@ -19,7 +16,9 @@ pub(crate) enum Message<C: Command> {
     AppendEntriesResponse(AppendEntriesResponse),
     VoteRequest(VoteRequest),
     VoteResponse(VoteResponse),
+    #[cfg_attr(not(test), expect(dead_code))]
     BecomeCandidate,
+    #[cfg_attr(not(test), expect(dead_code))]
     Command(C),
 }
 
@@ -71,144 +70,8 @@ pub(crate) struct VoteRequest {
     pub(crate) last_log_term: Term,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Arbitrary)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct VoteResponse {
     pub(crate) term: Term,
     pub(crate) vote_granted: bool,
-}
-
-impl<C: Command + Arbitrary + 'static> Arbitrary for Message<C>
-where
-    <C as Arbitrary>::Strategy: 'static,
-{
-    type Parameters = ();
-
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        prop_oneof![
-            any::<AppendEntriesRequest<C>>().prop_map(|append_entries_request| {
-                Message::AppendEntriesRequest(append_entries_request)
-            }),
-            any::<AppendEntriesResponse>().prop_map(|append_entries_response| {
-                Message::AppendEntriesResponse(append_entries_response)
-            }),
-            any::<VoteRequest>().prop_map(|vote_request| Message::VoteRequest(vote_request)),
-            any::<VoteResponse>().prop_map(|vote_response| Message::VoteResponse(vote_response)),
-            Just(Message::BecomeCandidate),
-            any::<C>().prop_map(|cmd| Message::Command(cmd))
-        ]
-        .boxed()
-    }
-
-    type Strategy = BoxedStrategy<Self>;
-}
-
-impl<C: Command + Arbitrary> Arbitrary for AppendEntriesRequest<C>
-where
-    <C as Arbitrary>::Strategy: 'static,
-{
-    type Parameters = ();
-
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (any::<Term>(), any::<NodeId>(), any::<Index>())
-            .prop_flat_map(|(term, leader_id, prev_log_index)| {
-                let prev_log_term = 0..=term;
-                // Limit entries to 5 to avoid proptest timeouts.
-                let entries = prop::collection::vec(LogEntry::<C>::arbitrary_with(term), 0..5);
-                (
-                    Just(term),
-                    Just(leader_id),
-                    Just(prev_log_index),
-                    prev_log_term,
-                    entries,
-                )
-            })
-            .prop_flat_map(
-                |(term, leader_id, prev_log_index, prev_log_term, entries)| {
-                    let max_commit_index = prev_log_index + entries.len() as Index;
-                    (
-                        Just(term),
-                        Just(leader_id),
-                        Just(prev_log_index),
-                        Just(prev_log_term),
-                        Just(entries),
-                        0..=max_commit_index,
-                    )
-                },
-            )
-            .prop_map(
-                |(term, leader_id, prev_log_index, prev_log_term, entries, leader_commit)| {
-                    AppendEntriesRequest {
-                        term,
-                        leader_id,
-                        prev_log_index,
-                        prev_log_term,
-                        entries,
-                        leader_commit,
-                    }
-                },
-            )
-            .boxed()
-    }
-
-    type Strategy = BoxedStrategy<Self>;
-}
-
-impl Arbitrary for AppendEntriesResponse {
-    type Parameters = ();
-
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (
-            any::<Term>(),
-            any::<bool>(),
-            any::<NodeId>(),
-            any::<NonZeroIndex>(),
-        )
-            .prop_flat_map(|(term, success, node_id, next_index)| {
-                let next_index = if success {
-                    Just(Some(next_index))
-                } else {
-                    Just(None)
-                };
-                (Just(term), Just(success), Just(node_id), next_index)
-            })
-            .prop_map(
-                |(term, success, node_id, next_index)| AppendEntriesResponse {
-                    term,
-                    success,
-                    node_id,
-                    next_index,
-                },
-            )
-            .boxed()
-    }
-
-    type Strategy = BoxedStrategy<Self>;
-}
-
-impl Arbitrary for VoteRequest {
-    type Parameters = ();
-
-    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (any::<Term>(), any::<NodeId>(), any::<Index>())
-            .prop_flat_map(|(term, candidate_id, last_log_index)| {
-                let last_log_term = (0..=term).boxed();
-                (
-                    Just(term),
-                    Just(candidate_id),
-                    Just(last_log_index),
-                    last_log_term,
-                )
-            })
-            .prop_map(
-                |(term, candidate_id, last_log_index, last_log_term)| VoteRequest {
-                    term,
-                    candidate_id,
-                    last_log_index,
-                    last_log_term,
-                },
-            )
-            .boxed()
-    }
-
-    type Strategy = BoxedStrategy<Self>;
 }

--- a/src/raft/prop_tests.rs
+++ b/src/raft/prop_tests.rs
@@ -1,0 +1,476 @@
+//! Property-based state-machine tests (single-node).
+
+use proptest::prelude::*;
+use proptest::test_runner::TestCaseResult;
+
+use super::*;
+use crate::raft::tests::{Cmd, TestStateMachine, TestStorage};
+use crate::state::{Index, Log};
+
+/// A minimal model to carry expectations across steps (single-node).
+#[derive(Clone, Debug)]
+struct Model {
+    last_term: Term,
+    last_commit_index: Index,
+    last_applied_index: Index,
+}
+
+impl<const N: usize> RaftCore<N, Cmd, TestStateMachine, TestStorage> {
+    fn model(&self) -> Model {
+        Model {
+            last_term: *self.log_state.current_term(),
+            last_commit_index: self.node_state.commit_index,
+            last_applied_index: self.node_state.last_applied,
+        }
+    }
+}
+
+fn check_invariants<const N: usize>(
+    node: &RaftCore<N, Cmd, TestStateMachine, TestStorage>,
+    model: &Model,
+) -> TestCaseResult {
+    // Term monotonicity.
+    prop_assert!(
+        *node.current_term() >= model.last_term,
+        "current term, {}, decreased from last term, {}",
+        node.current_term(),
+        model.last_term,
+    );
+    // Commit monotonicity.
+    prop_assert!(
+        node.node_state.commit_index >= model.last_commit_index,
+        "current commit index, {}, decreased from last commit index, {}",
+        node.node_state.commit_index,
+        model.last_commit_index,
+    );
+    // Applied monotonicity.
+    prop_assert!(
+        node.node_state.last_applied >= model.last_applied_index,
+        "current applied index, {}, decreased from last applied index, {}",
+        node.node_state.last_applied,
+        model.last_applied_index,
+    );
+    // Commit index never exceeds last log index.
+    prop_assert!(
+        node.node_state.commit_index <= node.log_state.log.last_index(),
+        "commit index, {}, exceeds last log index, {}",
+        node.node_state.commit_index,
+        node.log_state.log.last_index(),
+    );
+    // Applied never exceeds the commit index.
+    prop_assert!(
+        node.node_state.last_applied <= node.node_state.commit_index,
+        "applied index, {}, exceeds commit index, {}",
+        node.node_state.last_applied,
+        node.node_state.commit_index,
+    );
+    // Log terms are never larger than the current term.
+    prop_assert!(
+        node.log_state
+            .log
+            .inner()
+            .iter()
+            .all(|log_entry| log_entry.term <= *node.current_term()),
+        "log contains larger term than current term, {}; {:?}",
+        node.current_term(),
+        node.log_state.log,
+    );
+    // Log sorted by term.
+    prop_assert!(
+        node.log_state
+            .log
+            .inner()
+            .is_sorted_by_key(|log_entry| log_entry.term),
+        "log should be sorted by term: {:?}",
+        node.log_state.log
+    );
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct TestCase<const N: usize> {
+    node: RaftCore<N, Cmd, TestStateMachine, TestStorage>,
+    messages: Vec<Message<Cmd>>,
+}
+
+impl<const N: usize> Arbitrary for TestCase<N> {
+    type Parameters = ();
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any::<RaftCore<N, Cmd, TestStateMachine, TestStorage>>()
+            .prop_flat_map(|node| {
+                let last_index = node.log_state.log.last_index();
+                let message =
+                    any_with::<Message<Cmd>>((N, last_index, *node.log_state.current_term()));
+                let messages = prop::collection::vec(message, 64);
+
+                (Just(node), messages)
+            })
+            .prop_map(|(node, messages)| TestCase { node, messages })
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl<const N: usize, C, SM, S> Arbitrary for RaftCore<N, C, SM, S>
+where
+    C: Command + Arbitrary + 'static,
+    <C as Arbitrary>::Strategy: 'static,
+    SM: StateMachine<C> + Default,
+    S: Storage<C> + Default,
+{
+    type Parameters = ();
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        (0..N, any_with::<LogState<C>>(N))
+            .prop_flat_map(|(node_id, log_state)| {
+                let node_state = any_with::<NodeState>((N, log_state.log.last_index()));
+                let role = any_with::<RoleState<N>>(log_state.log.last_index());
+                (Just(node_id as NodeId), Just(log_state), node_state, role)
+            })
+            .prop_map(|(node_id, log_state, node_state, role)| RaftCore {
+                node_id,
+                log_state,
+                node_state,
+                role,
+                state_machine: SM::default(),
+                storage: S::default(),
+            })
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl<C: Command + Arbitrary + 'static> Arbitrary for LogState<C> {
+    type Parameters = usize;
+
+    fn arbitrary_with(num_nodes: Self::Parameters) -> Self::Strategy {
+        (any::<Term>(), 0..num_nodes, any::<bool>())
+            .prop_flat_map(|(current_term, voted_for, present)| {
+                let voted_for = if present {
+                    Some(voted_for as NodeId)
+                } else {
+                    None
+                };
+                let log = any_with::<Log<C>>(current_term);
+                (Just(current_term), Just(voted_for), log)
+            })
+            .prop_map(|(current_term, voted_for, log)| LogState::new(current_term, voted_for, log))
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl<C: Command + Arbitrary + 'static> Arbitrary for Log<C> {
+    type Parameters = Term;
+
+    fn arbitrary_with(max_term: Self::Parameters) -> Self::Strategy {
+        prop::collection::vec(any_with::<LogEntry<C>>(max_term), 0..256)
+            .prop_map(|mut log| {
+                // Log must be sorted by term.
+                log.sort_by_key(|log_entry| log_entry.term);
+                Log::from_inner(log)
+            })
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl<C: Command + Arbitrary> Arbitrary for LogEntry<C>
+where
+    <C as Arbitrary>::Strategy: 'static,
+{
+    type Parameters = Term;
+
+    fn arbitrary_with(max_term: Self::Parameters) -> Self::Strategy {
+        (0..=max_term, any::<C>())
+            .prop_map(|(term, command)| LogEntry { term, command })
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl Arbitrary for NodeState {
+    type Parameters = (usize, Index);
+
+    fn arbitrary_with((num_nodes, last_index): Self::Parameters) -> Self::Strategy {
+        (0..=last_index, 0..num_nodes, any::<bool>())
+            .prop_flat_map(|(commit_index, leader_id, present)| {
+                let leader_id = if present {
+                    Some(leader_id as NodeId)
+                } else {
+                    None
+                };
+                (Just(commit_index), 0..=commit_index, Just(leader_id))
+            })
+            .prop_map(|(commit_index, last_applied, leader_id)| NodeState {
+                commit_index,
+                last_applied,
+                leader_id,
+            })
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl<const N: usize> Arbitrary for RoleState<N> {
+    type Parameters = Index;
+
+    fn arbitrary_with(last_index: Self::Parameters) -> Self::Strategy {
+        prop_oneof![
+            Just(RoleState::Follower),
+            (0..=(N / 2)).prop_map(|votes| RoleState::Candidate { votes }),
+            any_with::<LeaderState<N>>(last_index)
+                .prop_map(|leader_state| RoleState::Leader { leader_state }),
+        ]
+        .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl<const N: usize> Arbitrary for LeaderState<N> {
+    type Parameters = Index;
+
+    fn arbitrary_with(last_index: Self::Parameters) -> Self::Strategy {
+        (
+            prop::collection::vec(1..=(last_index + 1), N),
+            prop::collection::vec(0..=last_index, N),
+        )
+            .prop_map(|(next_index_vec, match_index_vec)| {
+                let next_index_vec: Vec<_> = next_index_vec
+                    .into_iter()
+                    .map(|index| NonZeroIndex::new(index).unwrap())
+                    .collect();
+                let mut next_index = [NonZeroIndex::new(1).unwrap(); N];
+                next_index.copy_from_slice(&next_index_vec);
+
+                let mut match_index = [0; N];
+                match_index.copy_from_slice(&match_index_vec);
+
+                LeaderState {
+                    next_index,
+                    match_index,
+                }
+            })
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl<C: Command + Arbitrary + 'static> Arbitrary for Message<C>
+where
+    <C as Arbitrary>::Strategy: 'static,
+{
+    type Parameters = (usize, Index, Term);
+
+    fn arbitrary_with((num_nodes, last_index, current_term): Self::Parameters) -> Self::Strategy {
+        prop_oneof![
+            any_with::<AppendEntriesRequest<C>>((num_nodes, current_term)).prop_map(
+                |append_entries_request| { Message::AppendEntriesRequest(append_entries_request) }
+            ),
+            any_with::<AppendEntriesResponse>((num_nodes, last_index, current_term)).prop_map(
+                |append_entries_response| {
+                    Message::AppendEntriesResponse(append_entries_response)
+                }
+            ),
+            any_with::<VoteRequest>((num_nodes, current_term))
+                .prop_map(|vote_request| Message::VoteRequest(vote_request)),
+            any_with::<VoteResponse>(current_term)
+                .prop_map(|vote_response| Message::VoteResponse(vote_response)),
+            Just(Message::BecomeCandidate),
+            any::<C>().prop_map(|cmd| Message::Command(cmd))
+        ]
+        .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl<C: Command + Arbitrary> Arbitrary for AppendEntriesRequest<C>
+where
+    <C as Arbitrary>::Strategy: 'static,
+{
+    type Parameters = (usize, Term);
+
+    fn arbitrary_with((num_nodes, current_term): Self::Parameters) -> Self::Strategy {
+        (
+            any_message_term_with(current_term),
+            0..num_nodes,
+            any::<Index>(),
+        )
+            .prop_flat_map(|(term, leader_id, prev_log_index)| {
+                let prev_log_term = 0..=term;
+                // Limit entries to 5 to avoid proptest timeouts.
+                let entries = prop::collection::vec(any_with::<LogEntry<C>>(term), 0..5);
+                (
+                    Just(term),
+                    Just(leader_id as NodeId),
+                    Just(prev_log_index),
+                    prev_log_term,
+                    entries,
+                )
+            })
+            .prop_flat_map(
+                |(term, leader_id, prev_log_index, prev_log_term, entries)| {
+                    let max_commit_index = prev_log_index + entries.len() as Index;
+                    (
+                        Just(term),
+                        Just(leader_id),
+                        Just(prev_log_index),
+                        Just(prev_log_term),
+                        Just(entries),
+                        0..=max_commit_index,
+                    )
+                },
+            )
+            .prop_map(
+                |(term, leader_id, prev_log_index, prev_log_term, entries, leader_commit)| {
+                    AppendEntriesRequest {
+                        term,
+                        leader_id,
+                        prev_log_index,
+                        prev_log_term,
+                        entries,
+                        leader_commit,
+                    }
+                },
+            )
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl Arbitrary for AppendEntriesResponse {
+    type Parameters = (usize, Index, Term);
+
+    fn arbitrary_with((num_nodes, last_index, current_term): Self::Parameters) -> Self::Strategy {
+        (
+            any_message_term_with(current_term),
+            any::<bool>(),
+            0..num_nodes,
+            1..=(last_index + 1),
+        )
+            .prop_flat_map(|(term, success, node_id, next_index)| {
+                let next_index = if success {
+                    Just(Some(NonZeroIndex::new(next_index).unwrap()))
+                } else {
+                    Just(None)
+                };
+                (
+                    Just(term),
+                    Just(success),
+                    Just(node_id as NodeId),
+                    next_index,
+                )
+            })
+            .prop_map(
+                |(term, success, node_id, next_index)| AppendEntriesResponse {
+                    term,
+                    success,
+                    node_id,
+                    next_index,
+                },
+            )
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl Arbitrary for VoteRequest {
+    type Parameters = (usize, Term);
+
+    fn arbitrary_with((num_nodes, current_term): Self::Parameters) -> Self::Strategy {
+        (
+            // Vote requests are more interesting at non-equal terms, so generate a small range
+            // with equal probability around the current term.
+            current_term - 3..current_term + 3,
+            0..num_nodes,
+            any::<Index>(),
+        )
+            .prop_flat_map(|(term, candidate_id, last_log_index)| {
+                let last_log_term = (0..=term).boxed();
+                (
+                    Just(term),
+                    Just(candidate_id as NodeId),
+                    Just(last_log_index),
+                    last_log_term,
+                )
+            })
+            .prop_map(
+                |(term, candidate_id, last_log_index, last_log_term)| VoteRequest {
+                    term,
+                    candidate_id,
+                    last_log_index,
+                    last_log_term,
+                },
+            )
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl Arbitrary for VoteResponse {
+    type Parameters = Term;
+
+    fn arbitrary_with(current_term: Self::Parameters) -> Self::Strategy {
+        (any_message_term_with(current_term), any::<bool>())
+            .prop_map(|(term, vote_granted)| VoteResponse { term, vote_granted })
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+/// Generates a term for a message with an 80% chance of being the current term, 10% of being the
+/// previous term, and 10% of a later term.
+fn any_message_term_with(current_term: Term) -> BoxedStrategy<Term> {
+    prop_oneof![
+        8 => Just(current_term),
+        1 => ..current_term,
+        1 => current_term+1..,
+    ]
+    .boxed()
+}
+
+proptest! {
+    #[test]
+    fn raft_single_node_state_machine(TestCase {mut node, messages } in any::<TestCase<3>>()) {
+        // Check invariants at the beginning to make sure the test is valid.
+        check_invariants(&node, &node.model())?;
+
+        for message in messages {
+            let model = node.model();
+
+            // Execute operation on node. We ignore returned outgoing messages; we only assert invariants.
+            let (expect_ok, apply) = match message {
+                Message::AppendEntriesRequest(_)
+                | Message::AppendEntriesResponse(_)
+                | Message::VoteRequest(_)
+                | Message::VoteResponse(_) => (true, true),
+                Message::Command(_) => (false, true),
+                Message::BecomeCandidate => (true, node.role.role() == Role::Follower),
+            };
+
+            if apply {
+                let res = node.handle_message(message);
+                if expect_ok {
+                    prop_assert!(res.is_ok());
+                }
+            }
+
+            // Check invariants after each step.
+            check_invariants(&node, &model)?;
+        }
+    }
+}

--- a/src/raft/tests.rs
+++ b/src/raft/tests.rs
@@ -7,11 +7,11 @@ use crate::message::*;
 use crate::state::*;
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Arbitrary)]
-struct Cmd(i32);
+pub(crate) struct Cmd(i32);
 impl Command for Cmd {}
 
-#[derive(Default)]
-struct TestStateMachine {
+#[derive(Clone, Default)]
+pub(crate) struct TestStateMachine {
     applied: Vec<Cmd>,
 }
 impl StateMachine<Cmd> for TestStateMachine {
@@ -20,8 +20,8 @@ impl StateMachine<Cmd> for TestStateMachine {
     }
 }
 
-#[derive(Default)]
-struct TestStorage;
+#[derive(Clone, Default)]
+pub(crate) struct TestStorage;
 impl Storage<Cmd> for TestStorage {
     fn persist_state(
         _current_term: Option<Term>,
@@ -971,121 +971,4 @@ fn no_commit_prev_term() {
     assert_eq!(leader.node_state.commit_index, 0);
     assert_eq!(leader.node_state.last_applied, 0);
     assert_eq!(leader.state_machine.applied, Vec::new());
-}
-
-#[cfg(test)]
-mod prop_sm {
-    //! Property-based state-machine tests (single-node).
-
-    use proptest::prelude::*;
-    use proptest::test_runner::TestCaseResult;
-
-    use super::*;
-
-    /// A minimal model to carry expectations across steps (single-node).
-    #[derive(Clone, Debug, Default)]
-    struct Model {
-        last_term: Term,
-        last_commit_index: Index,
-        last_applied_index: Index,
-    }
-
-    // System Under Test wrapper.
-    struct Sut<const N: usize> {
-        node: RaftCore<N, Cmd, TestStateMachine, TestStorage>,
-    }
-
-    impl<const N: usize> Sut<N> {
-        fn new(node_id: NodeId) -> Self {
-            Self {
-                node: new_node::<N>(node_id),
-            }
-        }
-
-        fn check_invariants(&self, model: &Model) -> TestCaseResult {
-            // Term monotonicity.
-            prop_assert!(
-                *self.node.current_term() >= model.last_term,
-                "current term, {}, decreased from last term, {}",
-                self.node.current_term(),
-                model.last_term,
-            );
-            // Commit monotonicity.
-            prop_assert!(
-                self.node.node_state.commit_index >= model.last_commit_index,
-                "current commit index, {}, decreased from last commit index, {}",
-                self.node.node_state.commit_index,
-                model.last_commit_index,
-            );
-            // Applied monotonicity.
-            prop_assert!(
-                self.node.node_state.last_applied >= model.last_applied_index,
-                "current applied index, {}, decreased from last applied index, {}",
-                self.node.node_state.last_applied,
-                model.last_applied_index,
-            );
-            // Commit index never exceeds last log index.
-            prop_assert!(
-                self.node.node_state.commit_index <= self.node.log_state.log.last_index(),
-                "commit index, {}, exceeds last log index, {}",
-                self.node.node_state.commit_index,
-                self.node.log_state.log.last_index(),
-            );
-            // Applied never exceeds the commit index.
-            prop_assert!(
-                self.node.node_state.last_applied <= self.node.node_state.commit_index,
-                "applied index, {}, exceeds commit index, {}",
-                self.node.node_state.last_applied,
-                self.node.node_state.commit_index,
-            );
-            // Log terms are never larger than the current term.
-            prop_assert!(
-                self.node
-                    .log_state
-                    .log
-                    .inner()
-                    .iter()
-                    .all(|log_entry| log_entry.term <= *self.node.current_term()),
-                "log contains larger term than current term, {}; {:?}",
-                self.node.current_term(),
-                self.node.log_state.log,
-            );
-            Ok(())
-        }
-    }
-
-    proptest! {
-        // Use a small number of steps to keep test time reasonable in CI.
-        #[test]
-        fn raft_single_node_state_machine(ops in prop::collection::vec(any::<Message<Cmd>>(), 256)) {
-            let mut sut = Sut::<3>::new(1);
-            let mut model = Model::default();
-            for msg in ops.into_iter() {
-                // Execute operation on SUT. We ignore returned outgoing messages; we only assert invariants.
-                let (expect_ok, apply) = match msg {
-                    Message::AppendEntriesRequest(_)
-                    | Message::AppendEntriesResponse(_)
-                    | Message::VoteRequest(_)
-                    | Message::VoteResponse(_) => (true, true),
-                    Message::Command(_) => (false, true),
-                    Message::BecomeCandidate => (true, sut.node.role.role() == Role::Follower),
-                };
-
-                if apply {
-                    let res = sut.node.handle_message(msg);
-                    if expect_ok {
-                        prop_assert!(res.is_ok());
-                    }
-                }
-
-                // Check invariants after each step.
-                sut.check_invariants(&model)?;
-
-                // Update model.
-                model.last_term = *sut.node.current_term();
-                model.last_commit_index = sut.node.node_state.commit_index;
-                model.last_applied_index = sut.node.node_state.last_applied;
-            }
-        }
-    }
 }


### PR DESCRIPTION
Previously, the property tests would start with an initial Raft state,
generate a series of random messages, and then apply those messages in
order. The probability of reaching an interesting state via this method
is actually extremely low. For example, promoting a node to leader
requires generating two granted VoteResponse messages with the exact
same term, without generating a message with a higher term between
them. Another issue is that message terms are generated randomly from
the set of all u64s. That means the vast majority of terms are either
less than or greater than the node's term, which means most messages
are either ignored or cause a demotion. Most of the interesting
transitions happen when the terms match.

This commit modifies the property test so that it generates a random
valid Raft state and a series of random messages. Starting from a
random state makes it much more likely that we'll reach interesting
states. Additionally, messages are generated with a probabilistic term.
There's an 80% chance that the term will be the same as the node's term,
a 10% chance that it will be lower, and a 10% chance that it will be
higher.