### PR TITLE
Hook up Storage to state modifications

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ mod message;
 mod raft;
 mod simulation;
 mod state;
+mod storage;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,15 @@
+//! Module responsible for persisting the state of a Raft node.
+
+use crate::state::{Command, LogEntry, LogState, NodeId, NonZeroIndex, Term};
+
+/// Trait to persist state of a Raft node.
+pub trait Storage<C: Command> {
+    /// Read existing state, if it exists.
+    fn read_state(&self) -> Option<LogState<C>>;
+    /// Update the metadata of a Raft node.
+    fn persist_metadata(&self, current_term: Term, voted_for: Option<NodeId>);
+    /// Persist new log entries.
+    fn extend_log(&self, log: &[LogEntry<C>]);
+    /// Truncate existing log entries.
+    fn truncate_log(&self, start: NonZeroIndex);
+}


### PR DESCRIPTION
This commit adds more methods to the `Storage` trait to update the persisted Raft state and makes sure these methods are called when the state is modified. There is still some work/questions needed to make sure state is actually persisted correctly.

  - It's unclear if the current API makes the most sense.
  - Should the `Storage` trait be made async?
  - How should the log be serialized?