### PR TITLE
Implement non-deterministic parts of Raft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "derivative",
  "proptest",
  "proptest-derive",
+ "rand 0.9.2",
  "thiserror",
  "tokio",
  "turmoil",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ proptest-derive = "0.6.0"
 thiserror = "2.0.12"
 turmoil = "0.6.6"
 tokio = "1.45.1"
+rand = "0.9.2"
 
 [features]
 turmoil = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,12 +3,21 @@
 use crate::state::NodeId;
 use thiserror::Error;
 
+/// Error from sending a command to a Raft node.
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
-pub enum Error {
-    /// Indicates that an operation is only allowed on a leader, but was attempted on a different
+pub enum CommandError {
+    /// Indicates that commands are only allowed on a leader, but was attempted on a different
     /// role.
     ///
     /// Contains the [`NodeId`] of the current leader if it is known.
-    #[error("invalid operation on non-leader node")]
+    #[error("command not allowed on non-leader node")]
     NotLeader(Option<NodeId>),
+}
+
+/// Error from trying to transition a Raft node to the candidate role.
+#[derive(Error, Debug, PartialEq, Eq, Clone)]
+pub enum BecomeCandidateError {
+    /// Indicates that a leader cannot be promoted to a candidate.
+    #[error("cannot promote leader to candidate")]
+    IsLeader,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,11 @@ mod raft;
 mod simulation;
 mod state;
 mod storage;
+
+pub use error::{BecomeCandidateError, CommandError};
+pub use message::{
+    AppendEntriesRequest, AppendEntriesResponse, InterNodeMessage, VoteRequest, VoteResponse,
+};
+pub use raft::{CommandResponse, Raft, RaftCore, RaftHandle};
+pub use state::{Command, LogEntry, LogState, NodeId, NonZeroIndex, StateMachine, Term};
+pub use storage::Storage;

--- a/src/message.rs
+++ b/src/message.rs
@@ -10,68 +10,75 @@ macro_rules! unwrap_message {
     };
 }
 
+/// The set of all messages that the Raft state machine can receive from another node.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) enum Message<C: Command> {
+pub enum InterNodeMessage<C: Command> {
     AppendEntriesRequest(AppendEntriesRequest<C>),
     AppendEntriesResponse(AppendEntriesResponse),
     VoteRequest(VoteRequest),
     VoteResponse(VoteResponse),
-    #[cfg_attr(not(test), expect(dead_code))]
-    BecomeCandidate,
-    #[cfg_attr(not(test), expect(dead_code))]
-    Command(C),
 }
 
-impl<C: Command> Message<C> {
+impl<C: Command> InterNodeMessage<C> {
+    /// Returns the term of this message.
+    pub fn term(&self) -> Term {
+        match self {
+            InterNodeMessage::AppendEntriesRequest(msg) => msg.term,
+            InterNodeMessage::AppendEntriesResponse(msg) => msg.term,
+            InterNodeMessage::VoteRequest(msg) => msg.term,
+            InterNodeMessage::VoteResponse(msg) => msg.term,
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn unwrap_append_entries_request(self) -> AppendEntriesRequest<C> {
-        unwrap_message!(self, Message::AppendEntriesRequest)
+        unwrap_message!(self, InterNodeMessage::AppendEntriesRequest)
     }
 
     #[cfg(test)]
     pub(crate) fn unwrap_append_entries_response(self) -> AppendEntriesResponse {
-        unwrap_message!(self, Message::AppendEntriesResponse)
+        unwrap_message!(self, InterNodeMessage::AppendEntriesResponse)
     }
 
     #[cfg(test)]
     pub(crate) fn unwrap_vote_request(self) -> VoteRequest {
-        unwrap_message!(self, Message::VoteRequest)
+        unwrap_message!(self, InterNodeMessage::VoteRequest)
     }
 
     #[cfg(test)]
     pub(crate) fn unwrap_vote_response(self) -> VoteResponse {
-        unwrap_message!(self, Message::VoteResponse)
+        unwrap_message!(self, InterNodeMessage::VoteResponse)
     }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) struct AppendEntriesRequest<C: Command> {
-    pub(crate) term: Term,
-    pub(crate) leader_id: NodeId,
-    pub(crate) prev_log_index: Index,
-    pub(crate) prev_log_term: Term,
-    pub(crate) entries: Vec<LogEntry<C>>,
-    pub(crate) leader_commit: Index,
+pub struct AppendEntriesRequest<C: Command> {
+    pub term: Term,
+    pub leader_id: NodeId,
+    pub prev_log_index: Index,
+    pub prev_log_term: Term,
+    pub entries: Vec<LogEntry<C>>,
+    pub leader_commit: Index,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) struct AppendEntriesResponse {
-    pub(crate) term: Term,
-    pub(crate) success: bool,
-    pub(crate) node_id: NodeId,
-    pub(crate) next_index: Option<NonZeroIndex>,
+pub struct AppendEntriesResponse {
+    pub term: Term,
+    pub success: bool,
+    pub node_id: NodeId,
+    pub next_index: Option<NonZeroIndex>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) struct VoteRequest {
-    pub(crate) term: Term,
-    pub(crate) candidate_id: NodeId,
-    pub(crate) last_log_index: Index,
-    pub(crate) last_log_term: Term,
+pub struct VoteRequest {
+    pub term: Term,
+    pub candidate_id: NodeId,
+    pub last_log_index: Index,
+    pub last_log_term: Term,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) struct VoteResponse {
-    pub(crate) term: Term,
-    pub(crate) vote_granted: bool,
+pub struct VoteResponse {
+    pub term: Term,
+    pub vote_granted: bool,
 }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -5,27 +5,213 @@ mod prop_tests;
 #[cfg(test)]
 mod tests;
 
-use derivative::Derivative;
+use std::collections::VecDeque;
+use std::ops::{ControlFlow, RangeInclusive};
+use std::time::Duration;
 
-use crate::error::Error;
+use derivative::Derivative;
+use tokio::select;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::{Interval, interval};
+
+use crate::error::{BecomeCandidateError, CommandError};
 use crate::message::{
-    AppendEntriesRequest, AppendEntriesResponse, Message, VoteRequest, VoteResponse,
+    AppendEntriesRequest, AppendEntriesResponse, InterNodeMessage, VoteRequest, VoteResponse,
 };
 use crate::state::{
-    Command, LeaderState, LogEntry, LogState, NodeId, NodeState, NonZeroIndex, Role, RoleState,
-    Term,
+    Command, Index, LeaderState, LogEntry, LogState, NodeId, NodeState, NonZeroIndex, RoleState,
+    StateMachine, Term,
 };
 use crate::storage::Storage;
 
-pub trait StateMachine<C: Command> {
-    fn apply(&mut self, entry: &C);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(100);
+const ELECTION_TIMEOUT_MS_RANGE: RangeInclusive<u64> = 150..=300;
+
+/// Handle to communicate with a Raft node.
+pub struct RaftHandle<C: Command> {
+    incoming_tx: mpsc::UnboundedSender<InterNodeMessage<C>>,
+    outgoing_rx: mpsc::UnboundedReceiver<(NodeId, InterNodeMessage<C>)>,
+    command_tx: mpsc::UnboundedSender<(C, oneshot::Sender<Result<(), CommandError>>)>,
+}
+
+impl<C: Command> RaftHandle<C> {
+    /// Send an [`InterNodeMessage`] to a Raft node.
+    pub fn send_message(&self, message: InterNodeMessage<C>) {
+        let _ = self.incoming_tx.send(message);
+    }
+
+    /// Wait and receive the next [`InterNodeMessage`] from a Raft node, and the recipient of that
+    /// message.
+    ///
+    /// Returns `None` if the Raft node has stopped running.
+    pub async fn receive_message(&mut self) -> Option<(NodeId, InterNodeMessage<C>)> {
+        self.outgoing_rx.recv().await
+    }
+
+    /// Send a command to a Raft node.
+    pub fn send_command(&self, command: C) -> oneshot::Receiver<Result<(), CommandError>> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.command_tx.send((command, tx));
+        rx
+    }
+}
+
+/// The entire Raft algorithm for a single node, including the non-deterministic timing-based parts
+/// (heartbeats and election timers).
+pub struct Raft<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> {
+    core: RaftCore<N, C, SM, S>,
+
+    incoming_rx: mpsc::UnboundedReceiver<InterNodeMessage<C>>,
+    outgoing_tx: mpsc::UnboundedSender<(NodeId, InterNodeMessage<C>)>,
+    command_rx: mpsc::UnboundedReceiver<(C, oneshot::Sender<Result<(), CommandError>>)>,
+
+    election_timeout: Interval,
+    heartbeat: Interval,
+
+    awaiting_clients: VecDeque<(NonZeroIndex, oneshot::Sender<Result<(), CommandError>>)>,
+}
+
+impl<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> Raft<N, C, SM, S> {
+    /// Creates a new [`Raft`] that stores persistent state in `storage` and applies committed
+    /// commands to `state_machine`.
+    ///
+    /// Returns the [`Raft`] node and a [`RaftHandle`] to communicate with that node.
+    pub fn new(node_id: NodeId, state_machine: SM, storage: S) -> (Self, RaftHandle<C>) {
+        let core = RaftCore::new(node_id, state_machine, storage);
+
+        let (incoming_tx, incoming_rx) = mpsc::unbounded_channel();
+        let (outgoing_tx, outgoing_rx) = mpsc::unbounded_channel();
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+
+        let election_timeout = election_interval();
+        let heartbeat = interval(HEARTBEAT_INTERVAL);
+
+        let raft = Self {
+            core,
+            incoming_rx,
+            outgoing_tx,
+            command_rx,
+            election_timeout,
+            heartbeat,
+            awaiting_clients: VecDeque::new(),
+        };
+        let raft_handle = RaftHandle {
+            incoming_tx,
+            outgoing_rx,
+            command_tx,
+        };
+
+        (raft, raft_handle)
+    }
+
+    /// Run this [`Raft`] node until the [`RaftHandle`] used to communicate with it is dropped.
+    pub async fn run(mut self) {
+        // Reset interval to avoid the first tick which happens immediately.
+        self.election_timeout.reset();
+
+        loop {
+            let start_leader = self.core.role.is_leader();
+
+            select! {
+                _ = self.election_timeout.tick(), if !self.core.role.is_leader() => {
+                    let outgoings = self
+                        .core
+                        .handle_become_candidate()
+                        .expect("branch is guarded to only run when node is not a leader");
+                    if self.send_outgoings(outgoings).is_break() {
+                        return;
+                    }
+                }
+
+                _ = self.heartbeat.tick(), if self.core.role.is_leader() => {
+                    let outgoings = self.core.generate_heartbeats();
+                    if self.send_outgoings(outgoings).is_break() {
+                        return;
+                    }
+                }
+
+                Some(message) = self.incoming_rx.recv() => {
+                    if let InterNodeMessage::AppendEntriesRequest(AppendEntriesRequest {
+                        term, ..
+                    }) = &message
+                        && term >= self.core.log_state.current_term()
+                    {
+                        self.election_timeout.reset();
+                    }
+                    let outgoings = self.core.handle_inter_node_message(message);
+                    if self.send_outgoings(outgoings).is_break() {
+                        return;
+                    }
+                }
+
+                Some((command, response_tx)) = self.command_rx.recv() => {
+                    self.heartbeat.reset();
+                    match self.core.command(command) {
+                        Ok(CommandResponse {
+                            messages: outgoings,
+                            command_index,
+                        }) => {
+                            if self.send_outgoings(outgoings).is_break() {
+                                return;
+                            }
+
+                            self.awaiting_clients
+                                .push_back((command_index, response_tx));
+                        }
+                        Err(e) => {
+                            // Ignore errors if the sender has already hung up.
+                            let _ = response_tx.send(Err(e));
+                        }
+                    }
+                }
+
+                else => return,
+            }
+
+            while let Some((log_index, _)) = self.awaiting_clients.front()
+                && log_index.get() <= self.core.last_applied_index()
+            {
+                let (_, client_tx) = self
+                    .awaiting_clients
+                    .pop_front()
+                    .expect("branch is only taken when queue in non-empty");
+                // Ignore the error if the client has already hung up.
+                let _ = client_tx.send(Ok(()));
+            }
+
+            // Explicitly end the loop if either of the channels has been closed.
+            if self.incoming_rx.is_closed() || self.command_rx.is_closed() {
+                return;
+            }
+
+            // If we've been demoted, reset the election timeout so it doesn't immediately fire.
+            if start_leader && !self.core.role.is_leader() {
+                // Generate a new interval with a new random duration.
+                self.election_timeout = election_interval();
+                self.election_timeout.reset();
+            }
+            // If we've been promoted, reset the heartbeat interval so it does immediately fire.
+            if !start_leader && self.core.role.is_leader() {
+                self.heartbeat.reset_immediately();
+            }
+        }
+    }
+
+    fn send_outgoings(&self, outgoings: Vec<(NodeId, InterNodeMessage<C>)>) -> ControlFlow<()> {
+        for outgoing in outgoings {
+            if self.outgoing_tx.send(outgoing).is_err() {
+                return ControlFlow::Break(());
+            }
+        }
+        ControlFlow::Continue(())
+    }
 }
 
 /// The deterministic parts of the Raft algorithm for a single node. Specifically, this does not
 /// contain any timers or networking code.
 #[derive(Derivative, Clone)]
 #[derivative(Debug, PartialEq, Eq)]
-struct RaftCore<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> {
+pub struct RaftCore<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> {
     node_id: NodeId,
     log_state: LogState<C>,
     node_state: NodeState,
@@ -36,9 +222,10 @@ struct RaftCore<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> 
     storage: S,
 }
 
-#[cfg_attr(not(test), expect(dead_code))]
 impl<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> RaftCore<N, C, SM, S> {
-    fn new(node_id: NodeId, state_machine: SM, storage: S) -> Self {
+    /// Creates a new [`RaftCore`] that stores persistent state in `storage` and applies committed
+    /// commands to `state_machine`.
+    pub fn new(node_id: NodeId, state_machine: SM, storage: S) -> Self {
         Self {
             node_id,
             log_state: LogState::new(&storage),
@@ -49,60 +236,70 @@ impl<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> RaftCore<N,
         }
     }
 
-    fn handle_message(&mut self, msg: Message<C>) -> Result<Vec<(NodeId, Message<C>)>, Error> {
-        match msg {
-            Message::AppendEntriesRequest(append_entries_request) => {
+    /// Processes a [`InterNodeMessage`] and transitions state accordingly.
+    ///
+    /// Returns a list of messages to send in response and the recipient of those messages.
+    pub fn handle_inter_node_message(
+        &mut self,
+        inter_node_message: InterNodeMessage<C>,
+    ) -> Vec<(NodeId, InterNodeMessage<C>)> {
+        match inter_node_message {
+            InterNodeMessage::AppendEntriesRequest(append_entries_request) => {
                 let node_id = append_entries_request.leader_id;
                 let append_entries_response = self.append_entries_request(append_entries_request);
-                Ok(vec![(
+                vec![(
                     node_id,
-                    Message::AppendEntriesResponse(append_entries_response),
-                )])
+                    InterNodeMessage::AppendEntriesResponse(append_entries_response),
+                )]
             }
-            Message::AppendEntriesResponse(append_entries_response) => {
+            InterNodeMessage::AppendEntriesResponse(append_entries_response) => {
                 let node_id = append_entries_response.node_id;
                 let append_entries_request = self.append_entries_response(append_entries_response);
-                Ok(append_entries_request
+                append_entries_request
                     .into_iter()
                     .map(|append_entries_request| {
                         (
                             node_id,
-                            Message::AppendEntriesRequest(append_entries_request),
+                            InterNodeMessage::AppendEntriesRequest(append_entries_request),
                         )
                     })
-                    .collect())
+                    .collect()
             }
-            Message::VoteRequest(vote_request) => {
+            InterNodeMessage::VoteRequest(vote_request) => {
                 let node_id = vote_request.candidate_id;
                 let vote_response = self.vote_request(vote_request);
-                Ok(vec![(node_id, Message::VoteResponse(vote_response))])
+                vec![(node_id, InterNodeMessage::VoteResponse(vote_response))]
             }
-            Message::VoteResponse(vote_response) => {
+            InterNodeMessage::VoteResponse(vote_response) => {
                 self.vote_response(vote_response);
-                Ok(Vec::new())
+                Vec::new()
             }
-            Message::BecomeCandidate => {
-                let vote_request = self.become_candidate();
-                // TODO: Cloning the same message is a bit wasteful.
-                Ok((0..N)
-                    .map(|node_id| node_id as NodeId)
-                    .filter(|node_id| *node_id != self.node_id)
-                    .map(|peer| (peer, Message::VoteRequest(vote_request.clone())))
-                    .collect())
-            }
-            Message::Command(command) => match self.command(command) {
-                Ok(append_entries_requests) => Ok(append_entries_requests
-                    .into_iter()
-                    .map(|(node_id, append_entries_request)| {
-                        (
-                            node_id,
-                            Message::AppendEntriesRequest(append_entries_request),
-                        )
-                    })
-                    .collect()),
-                Err(leader_id) => Err(Error::NotLeader(leader_id)),
-            },
         }
+    }
+
+    /// Processes a command and transitions state accordingly.
+    pub fn handle_command(&mut self, command: C) -> Result<CommandResponse<C>, CommandError> {
+        self.command(command)
+    }
+
+    /// Processes a [`InterNodeMessage`] and transitions state accordingly.
+    ///
+    /// Returns a list of messages to send in response and the recipient of those messages, if
+    /// successful.
+    pub fn handle_become_candidate(
+        &mut self,
+    ) -> Result<Vec<(NodeId, InterNodeMessage<C>)>, BecomeCandidateError> {
+        let vote_request = self.become_candidate()?;
+        // TODO: Cloning the same message is a bit wasteful.
+        Ok(self
+            .peers()
+            .map(|peer| (peer, InterNodeMessage::VoteRequest(vote_request.clone())))
+            .collect())
+    }
+
+    /// Returns the index of the last applied command.
+    pub fn last_applied_index(&self) -> Index {
+        self.node_state.last_applied
     }
 
     /// Invoked by leader to replicate log entries (§5.3); also used as heartbeat (§5.2).
@@ -361,8 +558,11 @@ impl<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> RaftCore<N,
         }
     }
 
-    fn become_candidate(&mut self) -> VoteRequest {
-        assert_eq!(self.role.role(), Role::Follower);
+    fn become_candidate(&mut self) -> Result<VoteRequest, BecomeCandidateError> {
+        if self.role.is_leader() {
+            return Err(BecomeCandidateError::IsLeader);
+        }
+
         // Increment currentTerm.
         self.increment_term();
         self.role = RoleState::Candidate { votes: 0 };
@@ -374,7 +574,7 @@ impl<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> RaftCore<N,
             vote_granted: true,
         });
 
-        VoteRequest {
+        Ok(VoteRequest {
             term: *self.current_term(),
             candidate_id: self.node_id,
             last_log_index: self.log_state.log().last_index(),
@@ -384,30 +584,30 @@ impl<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> RaftCore<N,
                 .last()
                 .map(|entry| entry.term)
                 .unwrap_or(Term::MIN),
-        }
+        })
     }
 
-    fn command(
-        &mut self,
-        command: C,
-    ) -> Result<Vec<(NodeId, AppendEntriesRequest<C>)>, Option<NodeId>> {
+    fn command(&mut self, command: C) -> Result<CommandResponse<C>, CommandError> {
         if !self.role.is_leader() {
-            return Err(self.node_state.leader_id);
+            return Err(CommandError::NotLeader(self.node_state.leader_id));
         }
 
-        self.push_log(LogEntry {
+        let command_index = self.push_log(LogEntry {
             term: *self.current_term(),
             command,
         });
 
-        let mut append_entry_requests = Vec::with_capacity(N - 1);
+        let mut messages = Vec::with_capacity(N - 1);
         for node_id in 0..N {
             let node_id = node_id as NodeId;
             if node_id == self.node_id {
                 continue;
             }
-            let append_entry_request = self.generate_append_entry_request_for(node_id);
-            append_entry_requests.push((node_id, append_entry_request));
+            let append_entries_request = self.generate_append_entry_request_for(node_id);
+            messages.push((
+                node_id,
+                InterNodeMessage::AppendEntriesRequest(append_entries_request),
+            ));
         }
 
         // Update state for self.
@@ -422,7 +622,10 @@ impl<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> RaftCore<N,
             "updating self should never need to be retried"
         );
 
-        Ok(append_entry_requests)
+        Ok(CommandResponse {
+            messages,
+            command_index,
+        })
     }
 
     /// Generate [`AppendEntriesRequest`] for node `node_id`.
@@ -460,9 +663,29 @@ impl<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> RaftCore<N,
         }
     }
 
+    fn generate_heartbeats(&self) -> Vec<(NodeId, InterNodeMessage<C>)> {
+        self.peers()
+            .map(|node_id| {
+                let append_entry_request = AppendEntriesRequest {
+                    term: *self.log_state.current_term(),
+                    leader_id: self.node_id,
+                    prev_log_index: self.log_state.log().last_index(),
+                    prev_log_term: self.log_state.log().last_term().unwrap_or(Term::MIN),
+                    entries: Vec::new(),
+                    leader_commit: self.node_state.commit_index,
+                };
+                (
+                    node_id,
+                    InterNodeMessage::AppendEntriesRequest(append_entry_request),
+                )
+            })
+            .collect()
+    }
+
     /// If commitIndex > lastApplied: increment lastApplied, apply
     /// log[lastApplied] to state machine (§5.3).
     fn apply_committed_entries(&mut self) {
+        // TODO: Create dedicated task for this.
         while self.node_state.commit_index > self.node_state.last_applied {
             let entry = self
                 .log_state
@@ -513,7 +736,28 @@ impl<const N: usize, C: Command, SM: StateMachine<C>, S: Storage<C>> RaftCore<N,
         self.log_state.extend_log(entries, &self.storage);
     }
 
-    fn push_log(&mut self, entry: LogEntry<C>) {
-        self.log_state.push_log(entry, &self.storage);
+    fn push_log(&mut self, entry: LogEntry<C>) -> NonZeroIndex {
+        self.log_state.push_log(entry, &self.storage)
     }
+
+    /// Returns an iterator of all [`NodeId`]s, excluding the current node's ID.
+    fn peers(&self) -> impl Iterator<Item = NodeId> {
+        (0..N)
+            .map(|node_id| node_id as NodeId)
+            .filter(|node_id| *node_id != self.node_id)
+    }
+}
+
+/// A raft node's response to a [`Command`].
+#[derive(Debug)]
+pub struct CommandResponse<C: Command> {
+    /// Messages to send to other nodes in response to the command.
+    messages: Vec<(NodeId, InterNodeMessage<C>)>,
+    /// The index in the log of the command.
+    command_index: NonZeroIndex,
+}
+
+fn election_interval() -> Interval {
+    let election_timeout_ms = rand::random_range(ELECTION_TIMEOUT_MS_RANGE);
+    interval(Duration::from_millis(election_timeout_ms))
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,7 +4,7 @@ use crate::state::{Command, LogEntry, LogState, NodeId, NonZeroIndex, Term};
 
 /// Trait to persist state of a Raft node.
 pub trait Storage<C: Command> {
-    /// Read existing state, if it exists.
+    /// Read the existing state if it exists.
     fn read_state(&self) -> Option<LogState<C>>;
     /// Update the metadata of a Raft node.
     fn persist_metadata(&self, current_term: Term, voted_for: Option<NodeId>);


### PR DESCRIPTION
This commit implements the non-deterministic parts of the
[Raft consensus algorithm](https://raft.github.io/raft.pdf).
Specifically, it implements election timeouts and heartbeat timeouts.
Also, it implements the functionality to respond to clients after a
command has been committed.